### PR TITLE
readme point to voice assist mod correctly instead of copy paste from voice english

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,7 +55,6 @@ UNMUTING A SOUND:
   Uncomment (remove 2 dashes -- from line) the sounds you want unmuted in
     /Less-Slingload-Voice-Assist/Scripts/Speech/common_events.lua
 
-
 NOTE: If you want Russian a/c to still use English voice
       use the other mod, LESS SLINGLOAD VOICE ENGLISH
 https://github.com/flying-huckleberry/Less-Slingload-Voice-English/releases


### PR DESCRIPTION
i copy pasted english readme and forgot to change it to point to the regular voice assist mod instead of referencing itself